### PR TITLE
【WIP】【FOR CR ONLY】实现了一个debounce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ yarn-error.log*
 pnpm-debug.log*
 
 # Editor directories and files
-.vscode
 .idea
 *.suo
 *.ntvs*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "eslint.validate": ["vue", "javascript", "typescript", "javascriptreact", "typescriptreact"],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
 # ebook_reader
 
 ## Project setup
+
 ```
 npm install
 ```
 
 ### Compiles and hot-reloads for development
+
 ```
 npm run dev
 ```
 
 ### Compiles and minifies for production
+
 ```
 npm run build
 ```
 
 ### start local file serve
+
 ```
 npm run serve
 ```
+
+### vscode plugin
+
+- [johnsoncodehk.volar](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar)
+  > do not install **any other** vue plugin or disable them all!
+- [dbaeumer.vscode-eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [esbenp.prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- [mikestead.dotenv](https://marketplace.visualstudio.com/items?itemName=mikestead.dotenv)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { createApp } from 'vue'
-import { createPinia } from 'pinia'
+import { piniaInstance } from '@/plugins/pinia'
 import App from './App.vue'
 import './assets/style/main.scss'
 import router from './router'
@@ -20,4 +20,4 @@ app.directive('intersect', Intersect)
 app.directive('click-outside', ClickOutside)
 app.component('n-icon', NIcon)
 
-app.use(createPinia()).use(router).use(naive).mount('#app')
+app.use(piniaInstance).use(router).use(naive).mount('#app')

--- a/src/plugins/pinia/debounce/index.ts
+++ b/src/plugins/pinia/debounce/index.ts
@@ -1,0 +1,23 @@
+import { PiniaPluginContext } from 'pinia'
+import { debounce } from 'lodash'
+
+declare module 'pinia' {
+  export interface DefineStoreOptions<Id extends string, S extends StateTree, G, A>
+    extends DefineStoreOptionsBase<S, Store<Id, S, G, A>> {
+    debounce?: {
+      // allow defining a number of ms for any of the actions
+      [k in keyof A]?: number
+    }
+  }
+}
+
+/** 允许定义store时对某些action设置 debounce */
+export function debounceAction({ options, store }: PiniaPluginContext) {
+  if (options.debounce) {
+    // we are overriding the actions with new ones
+    return Object.keys(options.debounce).reduce((debouncedActions, action) => {
+      debouncedActions[action] = debounce(store[action], options.debounce![action])
+      return debouncedActions
+    }, {} as any)
+  }
+}

--- a/src/plugins/pinia/index.ts
+++ b/src/plugins/pinia/index.ts
@@ -1,0 +1,7 @@
+import { createPinia } from 'pinia'
+import { debounceAction } from './debounce'
+
+const piniaInstance = createPinia()
+piniaInstance.use(debounceAction)
+
+export { piniaInstance }


### PR DESCRIPTION
实现了个type-safe的plugin；

实践下来的想法是：
1. plugin最后的类型校验体验不好，大致解释：
1.1. defineStore函数用了很多推导，由用户代码推导类型，比如你写了 state 包含一个test，初始值是string类型，那么action拿到的store就包含这个test
1.2. 问题来了：plugin如果要依赖state或者action，那么这个时候，你没写完你的定义时，ts会因为你没写完等原因导致推导无法进行，也就是，debounce里没法拿到action的key作为代码提示，只能等你写完之后再校验
1.3. 也因为是推导校验，所以ts只知道你写的类型“互相不匹配”，但不知道以哪个为准，所以彪红会整个定义彪
2. 尽量做一些类型透明的plugin，这样可以最大限度避开上边说的问题